### PR TITLE
Parties panel (Mon–Sat) + routing wire + ICS (token-only)

### DIFF
--- a/frontend/src/assets/js/home-panel.js
+++ b/frontend/src/assets/js/home-panel.js
@@ -1,0 +1,73 @@
+/**
+ * Home panel: two sections (Parties / Map), each with Mon–Sat pills.
+ * Routes: #/parties/YYYY-MM-DD and #/map/YYYY-MM-DD
+ */
+export async function getMonSatDates() {
+  let data = [];
+  try {
+    const r = await fetch('/api/parties?conference=gamescom2025', { headers: { accept: 'application/json' }});
+    const raw = await r.json();
+    const list = Array.isArray(raw?.data) ? raw.data
+               : Array.isArray(raw?.parties) ? raw.parties
+               : Array.isArray(raw) ? raw : [];
+    data = list;
+  } catch { /* fallback below */ }
+
+  const toISO = s => (s || '').slice(0,10);
+  const day = iso => new Date(iso + 'T00:00:00').getDay(); // 0..6
+  let uniq = Array.from(new Set(
+    data.map(p => toISO(p.start || p.startsAt || p.date || ''))
+  )).filter(Boolean).sort();
+
+  // Keep Mon..Sat; fallback to next Mon..Sat if empty
+  let monSat = uniq.filter(iso => (day(iso) >= 1 && day(iso) <= 6));
+  if (!monSat.length) {
+    const now = new Date();
+    const nextMon = new Date(now);
+    nextMon.setDate(now.getDate() + ((1 - now.getDay() + 7) % 7 || 7)); // next Monday
+    monSat = Array.from({length:6}, (_,i) => {
+      const d = new Date(nextMon); d.setDate(nextMon.getDate()+i);
+      return d.toISOString().slice(0,10);
+    });
+  }
+  return monSat.slice(0,6);
+}
+
+function pillLabel(iso) {
+  const d = new Date(iso + 'T00:00:00');
+  const w = d.toLocaleDateString(undefined, { weekday:'short' });
+  const dd = d.toLocaleDateString(undefined, { day:'2-digit' });
+  return `${w} ${dd}`;
+}
+
+export function renderHomePanel(root, dates) {
+  root.innerHTML = `
+    <section class="home-panel">
+      <div class="home-section">
+        <h2 class="home-h2">Parties</h2>
+        <div class="pill-row" data-kind="parties">
+          ${dates.map(iso => `
+            <button class="day-pill" data-route="#/parties/${iso}" aria-pressed="false">${pillLabel(iso)}</button>
+          `).join('')}
+        </div>
+      </div>
+      <div class="home-section">
+        <h2 class="home-h2">Map</h2>
+        <div class="pill-row" data-kind="map">
+          ${dates.map((iso,i) => `
+            <button class="day-pill" data-route="#/map/${iso}" aria-pressed="${i===0?'true':'false'}">${pillLabel(iso)}</button>
+          `).join('')}
+        </div>
+      </div>
+    </section>
+  `;
+}
+
+export function wireHomePanel(root) {
+  root.addEventListener('click', (e) => {
+    const btn = e.target.closest('.day-pill');
+    if (!btn) return;
+    const to = btn.dataset.route;
+    if (to) location.hash = to;
+  });
+}

--- a/frontend/src/assets/js/home-router-hotfix.js
+++ b/frontend/src/assets/js/home-router-hotfix.js
@@ -1,0 +1,59 @@
+import { getMonSatDates, renderHomePanel, wireHomePanel } from './home-panel.js';
+
+function byId(id){ return document.getElementById(id) || document.querySelector('#app') || document.body; }
+async function mountHome() {
+  const mount = byId('app');
+  const dates = await getMonSatDates();
+  renderHomePanel(mount, dates);
+  wireHomePanel(mount);
+}
+
+async function onRoute() {
+  const h = location.hash || '';
+  if (!h || h === '#/' || h === '#/home') {
+    await mountHome();
+    return;
+  }
+  // For parties/map, keep your existing panels.
+  // If none exists, provide minimal fallback for parties.
+  const mParties = /^#\/parties\/(\d{4}-\d{2}-\d{2})$/.exec(h);
+  if (mParties) {
+    const date = mParties[1];
+    const root = byId('app');
+    try {
+      const r = await fetch('/api/parties?conference=gamescom2025', { headers:{accept:'application/json'} });
+      const raw = await r.json();
+      const list = Array.isArray(raw?.data) ? raw.data
+                 : Array.isArray(raw?.parties) ? raw.parties
+                 : Array.isArray(raw) ? raw : [];
+      const items = list.filter(e => (e.start || e.startsAt || e.date || '').slice(0,10) === date);
+      root.innerHTML = `
+        <section class="parties-panel">
+          <h2 class="home-h2">Parties • ${date}</h2>
+          <div class="card-grid">
+            ${items.map(e => `
+              <article class="vcard">
+                <header class="vcard__head"><h3>${(e.title||e.name||'Party')}</h3></header>
+                <div class="vcard__body">
+                  <p>${(e.venue||e.location?.name||'')}</p>
+                  <p>${(e.start||e.startsAt||'').replace('T',' ')}</p>
+                </div>
+              </article>
+            `).join('')}
+          </div>
+        </section>
+      `;
+    } catch {
+      await mountHome();
+    }
+    return;
+  }
+  // If your existing router mounts the Map panel, let it handle #/map/DATE.
+  // Otherwise do nothing here (avoids conflicts). You already fixed the Maps loader.
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  if (!location.hash) location.hash = '#/home';
+  onRoute();
+});
+window.addEventListener('hashchange', onRoute);

--- a/frontend/src/assets/js/home-router-hotfix.js
+++ b/frontend/src/assets/js/home-router-hotfix.js
@@ -1,4 +1,5 @@
 import { getMonSatDates, renderHomePanel, wireHomePanel } from './home-panel.js';
+import { mountPartiesPanel } from './panels/parties-panel-lite.js';
 
 function byId(id){ return document.getElementById(id) || document.querySelector('#app') || document.body; }
 async function mountHome() {
@@ -19,33 +20,7 @@ async function onRoute() {
   const mParties = /^#\/parties\/(\d{4}-\d{2}-\d{2})$/.exec(h);
   if (mParties) {
     const date = mParties[1];
-    const root = byId('app');
-    try {
-      const r = await fetch('/api/parties?conference=gamescom2025', { headers:{accept:'application/json'} });
-      const raw = await r.json();
-      const list = Array.isArray(raw?.data) ? raw.data
-                 : Array.isArray(raw?.parties) ? raw.parties
-                 : Array.isArray(raw) ? raw : [];
-      const items = list.filter(e => (e.start || e.startsAt || e.date || '').slice(0,10) === date);
-      root.innerHTML = `
-        <section class="parties-panel">
-          <h2 class="home-h2">Parties • ${date}</h2>
-          <div class="card-grid">
-            ${items.map(e => `
-              <article class="vcard">
-                <header class="vcard__head"><h3>${(e.title||e.name||'Party')}</h3></header>
-                <div class="vcard__body">
-                  <p>${(e.venue||e.location?.name||'')}</p>
-                  <p>${(e.start||e.startsAt||'').replace('T',' ')}</p>
-                </div>
-              </article>
-            `).join('')}
-          </div>
-        </section>
-      `;
-    } catch {
-      await mountHome();
-    }
+    await mountPartiesPanel(date);
     return;
   }
   // If your existing router mounts the Map panel, let it handle #/map/DATE.

--- a/frontend/src/assets/js/panels/parties-panel-lite.js
+++ b/frontend/src/assets/js/panels/parties-panel-lite.js
@@ -1,0 +1,97 @@
+/**
+ * Parties panel (lite): renders parties for a YYYY-MM-DD date.
+ * Fallback ICS add-to-calendar (client-side) to ensure UX works without backend.
+ */
+function escape(s=''){ return String(s).replace(/[&<>"]/g, m=>({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;' }[m])); }
+function isoDate(s){ return (s||'').slice(0,10); }
+function toICSDate(s){
+  // accepts ISO like 2025-08-21T19:00:00Z or 2025-08-21
+  const d = s && s.length>10 ? new Date(s) : new Date(s+'T00:00:00');
+  const pad = n => String(n).padStart(2,'0');
+  const y=d.getUTCFullYear(), m=pad(d.getUTCMonth()+1), day=pad(d.getUTCDate());
+  const hh=pad(d.getUTCHours()), mm=pad(d.getUTCMinutes()), ss=pad(d.getUTCSeconds());
+  return `${y}${m}${day}T${hh}${mm}${ss}Z`;
+}
+function buildICS(evt){
+  const uid = `party-${(evt.id||evt.title||evt.name||'x').replace(/\W+/g,'-')}@conference-party-app`;
+  const dtStart = toICSDate(evt.start || evt.startsAt || evt.date);
+  const dtEnd   = toICSDate(evt.end   || evt.endsAt   || evt.start || evt.date);
+  const title   = escape(evt.title || evt.name || 'Party');
+  const loc     = escape(evt.venue || evt.location?.name || '');
+  const desc    = escape((evt.description || '').slice(0,1000));
+  return [
+    'BEGIN:VCALENDAR','VERSION:2.0','PRODID:-//Conference Party App//EN','CALSCALE:GREGORIAN',
+    'BEGIN:VEVENT',
+    `UID:${uid}`,
+    `DTSTAMP:${toICSDate(new Date().toISOString())}`,
+    `DTSTART:${dtStart}`,
+    `DTEND:${dtEnd}`,
+    `SUMMARY:${title}`,
+    loc && `LOCATION:${loc}`,
+    desc && `DESCRIPTION:${desc}`,
+    'END:VEVENT','END:VCALENDAR',''
+  ].filter(Boolean).join('\r\n');
+}
+function downloadICS(evt){
+  const ics = buildICS(evt);
+  const blob = new Blob([ics], { type:'text/calendar;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  const date = isoDate(evt.start||evt.startsAt||evt.date)||'date';
+  a.href = url; a.download = `party-${date}.ics`;
+  document.body.appendChild(a); a.click(); a.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+export async function mountPartiesPanel(dateISO){
+  const mount = document.getElementById('app') || document.body;
+  mount.innerHTML = `
+    <section class="parties-panel">
+      <h2 class="home-h2">Parties • ${dateISO}</h2>
+      <div class="card-grid" id="parties-list" aria-live="polite"></div>
+    </section>
+  `;
+  const listEl = mount.querySelector('#parties-list');
+
+  let raw;
+  try {
+    const r = await fetch('/api/parties?conference=gamescom2025', { headers:{accept:'application/json'} });
+    raw = await r.json();
+  } catch (e) {
+    listEl.innerHTML = `<p class="empty-state">Could not load parties.</p>`;
+    return;
+  }
+  const all = Array.isArray(raw?.data) ? raw.data
+           : Array.isArray(raw?.parties) ? raw.parties
+           : Array.isArray(raw) ? raw : [];
+  const items = all.filter(e => isoDate(e.start||e.startsAt||e.date) === dateISO);
+
+  if (!items.length){
+    listEl.innerHTML = `<p class="empty-state">No parties for ${dateISO}.</p>`;
+    return;
+  }
+
+  listEl.innerHTML = items.map(evt => {
+    const title = escape(evt.title||evt.name||'Party');
+    const when  = escape((evt.start||evt.startsAt||'').replace('T',' ').slice(0,16));
+    const where = escape(evt.venue || evt.location?.name || '');
+    return `
+      <article class="vcard">
+        <header class="vcard__head"><h3>${title}</h3></header>
+        <div class="vcard__body">
+          ${where ? `<p>${where}</p>`:''}
+          ${when  ? `<p>${when}</p>`:''}
+        </div>
+        <footer class="vcard__foot">
+          <button class="btn-add-to-calendar" data-evt='${encodeURIComponent(JSON.stringify(evt))}'>Add to Calendar</button>
+        </footer>
+      </article>`;
+  }).join('');
+
+  listEl.addEventListener('click', (e)=>{
+    const btn = e.target.closest('.btn-add-to-calendar');
+    if(!btn) return;
+    const evt = JSON.parse(decodeURIComponent(btn.dataset.evt||'%7B%7D'));
+    downloadICS(evt);
+  });
+}

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -34,5 +34,7 @@
   <script type="module" src="/dist/js/stack.js"></script>
   <script type="module" src="/dist/js/router-stack.js"></script>
   <script defer src="/js/boot/map-boot.js"></script>
+  <script type="module" src="/assets/js/home-panel.js" defer></script>
+  <script type="module" src="/assets/js/home-router-hotfix.js" defer></script>
 </body>
 </html>

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -18,8 +18,8 @@
   <link rel="stylesheet" href="/assets/css/components.css">
   <link rel="stylesheet" href="/assets/css/calendar-buttons.css">
   <!-- Home panel styles must load before cards-final to allow cascade -->
-  <link rel="stylesheet" href="/assets/css/home.css?v=b033">
-  <link rel="stylesheet" href="/assets/css/cards-final.css?v=b033">
+  <link rel="stylesheet" href="/assets/css/home.css?v=1755355966">
+  <link rel="stylesheet" href="/assets/css/cards-final.css?v=1755355966">
 </head>
 <body>
   <div id="app">


### PR DESCRIPTION
Adds Mon–Sat Parties routes (#/parties/YYYY-MM-DD), renders cards with ICS fallback, keeps Map handled by existing code. Ensures CSS order and cache-bust. No router overhaul.