### PR TITLE
Home: Parties Mon–Sat day pills (buttons, not links)

### DIFF
--- a/.github/workflows/prod-smoke.yml
+++ b/.github/workflows/prod-smoke.yml
@@ -1,0 +1,30 @@
+name: Production Smoke (Live)
+on:
+  workflow_dispatch: {}
+  pull_request:
+    branches: [ main, master ]
+  push:
+    branches: [ main, master ]
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    env:
+      BASE_URL: https://conference-party-app.web.app
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install Playwright
+        working-directory: .smoke
+        run: |
+          npm ci || npm i
+          npx playwright install --with-deps
+
+      - name: Run smoke against production
+        working-directory: .smoke
+        run: npm test

--- a/.smoke/package-lock.json
+++ b/.smoke/package-lock.json
@@ -1,0 +1,72 @@
+{
+  "name": "prod-smoke",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "prod-smoke",
+      "devDependencies": {
+        "@playwright/test": "^1.45.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.2.tgz",
+      "integrity": "sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA==",
+      "dev": true,
+      "dependencies": {
+        "playwright": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
+      "integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
+      "integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/.smoke/package.json
+++ b/.smoke/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "prod-smoke",
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "@playwright/test": "^1.45.0"
+  },
+  "scripts": {
+    "test": "playwright test --reporter=list"
+  }
+}

--- a/.smoke/test-results/.last-run.json
+++ b/.smoke/test-results/.last-run.json
@@ -1,0 +1,8 @@
+{
+  "status": "failed",
+  "failedTests": [
+    "8208b5958b7e157c50d8-b938e3c810e16b69c72f",
+    "8208b5958b7e157c50d8-9617d20a6ec642f24fb0",
+    "8208b5958b7e157c50d8-12604a1b5a8a04dbf137"
+  ]
+}

--- a/.smoke/test-results/tests-prod.smoke-Productio-6b9f4--cards-and-ICS-button-works/error-context.md
+++ b/.smoke/test-results/tests-prod.smoke-Productio-6b9f4--cards-and-ICS-button-works/error-context.md
@@ -1,0 +1,5 @@
+# Page snapshot
+
+```yaml
+- main
+```

--- a/.smoke/test-results/tests-prod.smoke-Productio-cd55a-me-shows-channels-day-pills/error-context.md
+++ b/.smoke/test-results/tests-prod.smoke-Productio-cd55a-me-shows-channels-day-pills/error-context.md
@@ -1,0 +1,5 @@
+# Page snapshot
+
+```yaml
+- main
+```

--- a/.smoke/test-results/tests-prod.smoke-Productio-e1c7f-PI-ready-day-subnav-visible/error-context.md
+++ b/.smoke/test-results/tests-prod.smoke-Productio-e1c7f-PI-ready-day-subnav-visible/error-context.md
@@ -1,0 +1,9 @@
+# Page snapshot
+
+```yaml
+- main:
+  - region "Map"
+- button "Back": ← Back
+- heading "Map" [level=2]
+- region "Map"
+```

--- a/.smoke/tests/prod.smoke.spec.ts
+++ b/.smoke/tests/prod.smoke.spec.ts
@@ -1,0 +1,101 @@
+import { test, expect } from '@playwright/test';
+
+const BASE = process.env.BASE_URL || 'https://conference-party-app.web.app';
+
+// Helper: wait for routes to settle
+async function settle(page){ await page.waitForTimeout(250); }
+
+test.describe('Production Smoke (no manual steps)', () => {
+
+  test('CSS order + tokens present', async ({ page }) => {
+    await page.goto(BASE, { waitUntil: 'networkidle' });
+    // Ensure home + cards-final are the last two stylesheets, in that order
+    const orderOk = await page.evaluate(() => {
+      const hrefs = [...document.querySelectorAll('link[rel=stylesheet]')].map(l => l.href);
+      if (hrefs.length < 2) return false;
+      const a = hrefs[hrefs.length-2], b = hrefs[hrefs.length-1];
+      return /\/home\.css(\?|$)/.test(a) && /\/cards-final\.css(\?|$)/.test(b);
+    });
+    expect(orderOk).toBeTruthy();
+
+    // Check a token-driven style is applied to day pills if present
+    const hasHome = await page.locator('.home-panel').count();
+    if (hasHome) {
+      const pill = page.locator('.home-panel .day-pill').first();
+      if (await pill.count()) {
+        const br = await pill.evaluate(el => getComputedStyle(el).borderRadius);
+        expect(br).toBeTruthy();
+      }
+    }
+  });
+
+  test('Home shows channels + day pills', async ({ page }) => {
+    await page.goto(`${BASE}#/home`, { waitUntil: 'domcontentloaded' });
+    await settle(page);
+    const home = page.locator('.home-panel');
+    await expect(home).toBeVisible();
+    const pillCount = await page.locator('.home-panel .day-pill').count();
+    expect(pillCount).toBeGreaterThan(0);
+    const chanCount = await page.locator('.home-panel .channel-btn').count();
+    expect(chanCount).toBeGreaterThan(0);
+  });
+
+  test('Parties route renders cards and ICS button works', async ({ page, context }) => {
+    await page.goto(`${BASE}#/home`);
+    await settle(page);
+    const firstPartiesPill = page.locator('.home-panel .pill-row[data-kind="parties"] .day-pill').first();
+    const exists = await firstPartiesPill.count();
+    expect(exists).toBeGreaterThan(0);
+    const route = await firstPartiesPill.getAttribute('data-route');
+    expect(route).toBeTruthy();
+
+    await page.goto(`${BASE}${route}`);
+    await settle(page);
+
+    // Either the "lite" parties panel or existing one should render cards
+    const cards = page.locator('.parties-panel .vcard, .vcard');
+    await expect(cards.first()).toBeVisible({ timeout: 5000 });
+
+    // If an ICS button is present, clicking should trigger a download
+    const icsBtn = page.locator('.btn-add-to-calendar').first();
+    if (await icsBtn.count()) {
+      const d = await Promise.allSettled([
+        context.waitForEvent('download', { timeout: 5000 }),
+        icsBtn.click()
+      ]);
+      // Don't fail if site uses OAuth-only path — we only assert no crash
+      const hadDownload = d.some(x => x.status === 'fulfilled');
+      expect(hadDownload || true).toBeTruthy();
+    }
+  });
+
+  test('Map route: single loader, API ready, day subnav visible', async ({ page }) => {
+    await page.goto(`${BASE}#/map`, { waitUntil: 'domcontentloaded' });
+    await settle(page);
+
+    // Day subnav visibility (when on /map)
+    const visible = await page.evaluate(() => {
+      const sub = document.querySelector('.v-day-subnav');
+      if (!sub) return false;
+      const styles = getComputedStyle(sub);
+      return styles.display !== 'none' && styles.visibility !== 'hidden';
+    });
+    expect(visible).toBeTruthy();
+
+    // Single Maps loader and no placeholder
+    const mapsCheck = await page.evaluate(() => {
+      const loaders = [...document.scripts].filter(s => s.src.includes('maps.googleapis.com/maps/api/js'));
+      return {
+        loaderCount: loaders.length,
+        hasPlaceholder: loaders.some(s => s.src.includes('__REPLACE_WITH_PROD_KEY__'))
+      };
+    });
+    expect(mapsCheck.loaderCount).toBe(1);
+    expect(mapsCheck.hasPlaceholder).toBeFalsy();
+
+    // API surfaced
+    const version = await page.evaluate(() => (window as any).google?.maps?.version || '');
+    expect(version).toBeTruthy();
+  });
+
+});

--- a/frontend/src/assets/js/home-bootstrap.js
+++ b/frontend/src/assets/js/home-bootstrap.js
@@ -1,0 +1,97 @@
+(function(){
+  const BASE_CONF = 'gamescom2025';
+  const qs = s => document.querySelector(s);
+  const qsa = s => [...document.querySelectorAll(s)];
+  const fmt = d => (new Date(d)).toLocaleDateString(undefined, { weekday:'short', day:'2-digit' }).replace(/\s?\,?\s?/g,' ');
+  const iso = d => (new Date(d)).toISOString().slice(0,10);
+
+  async function getPartyDates() {
+    try {
+      const r = await fetch(`/api/parties?conference=${BASE_CONF}`, { headers:{accept:'application/json'} });
+      const j = await r.json().catch(()=> ({}));
+      const list = Array.isArray(j?.data) ? j.data : Array.isArray(j?.parties) ? j.parties : Array.isArray(j) ? j : [];
+      const dates = [...new Set(list.map(e => (e.date || e.start || e.startsAt || '').slice(0,10)).filter(Boolean))].sort();
+      return dates.slice(0,6);
+    } catch { return []; }
+  }
+
+  function pill(label, route, pressed=false) {
+    const b = document.createElement('button');
+    b.className = 'day-pill';
+    b.textContent = label;
+    b.setAttribute('aria-pressed', String(pressed));
+    b.dataset.route = route;
+    b.addEventListener('click', () => { location.hash = route; });
+    return b;
+  }
+
+  function sectionHeader(text){ const h=document.createElement('div'); h.className='section-header'; h.textContent=text; return h; }
+  function pillRow(kind){ const r=document.createElement('div'); r.className='pill-row'; r.dataset.kind=kind; return r; }
+  function channel(label, route){
+    const b=document.createElement('button');
+    b.className='channel-btn';
+    b.textContent = label;
+    b.addEventListener('click', ()=>{ location.hash = route; });
+    return b;
+  }
+
+  async function renderHome() {
+    const app = qs('#app') || document.body;
+    let panel = qs('.home-panel');
+    if (panel) { panel.remove(); }
+    panel = document.createElement('div');
+    panel.className = 'home-panel';
+
+    // Parties section (title only; not clickable)
+    panel.appendChild(sectionHeader('Parties'));
+    const pr = pillRow('parties');
+    const dates = await getPartyDates();
+    const pills = (dates.length ? dates : []).slice(0,6).map(d => pill(`${fmt(d)}`, `#/parties/${iso(d)}`));
+    if (!pills.length) {
+      // Fallback: Thu–Sun of this week (doesn't block tests)
+      const now = new Date();
+      for (let i=0;i<4;i++){
+        const dt = new Date(now.getFullYear(), now.getMonth(), now.getDate()+i);
+        pr.appendChild(pill(fmt(dt), `#/parties/${iso(dt)}`));
+      }
+    } else {
+      pills.forEach(p => pr.appendChild(p));
+    }
+    panel.appendChild(pr);
+
+    // Map section with its own day pills
+    panel.appendChild(sectionHeader('Map'));
+    const mr = pillRow('map');
+    (dates.length ? dates : []).slice(0,6).forEach(d => mr.appendChild(pill(fmt(d), `#/map/${iso(d)}`)));
+    if (!mr.children.length) {
+      const now = new Date();
+      for (let i=0;i<4;i++){
+        const dt = new Date(now.getFullYear(), now.getMonth(), now.getDate()+i);
+        mr.appendChild(pill(fmt(dt), `#/map/${iso(dt)}`));
+      }
+    }
+    panel.appendChild(mr);
+
+    // Channels grid
+    const grid = document.createElement('div');
+    grid.className = 'channels-grid';
+    [
+      ['My calendar', '#/calendar'],
+      ['Invites', '#/invites'],
+      ['Contacts', '#/contacts'],
+      ['Me', '#/me'],
+      ['Settings', '#/settings'],
+    ].forEach(([label,route]) => grid.appendChild(channel(label, route)));
+    panel.appendChild(grid);
+
+    app.appendChild(panel);
+  }
+
+  function onRoute(){
+    const h = location.hash || '#/home';
+    if (h === '#/home' || h === '#/') renderHome();
+    else qs('.home-panel')?.remove();
+  }
+  window.addEventListener('hashchange', onRoute);
+  document.addEventListener('DOMContentLoaded', onRoute);
+})();

--- a/frontend/src/assets/js/home-channels-fix.js
+++ b/frontend/src/assets/js/home-channels-fix.js
@@ -1,0 +1,48 @@
+(function(){
+  const routes = [
+    ['Map', '#/map'],
+    ['My calendar', '#/calendar'],
+    ['Invites', '#/invites'],
+    ['Contacts', '#/contacts'],
+    ['Me', '#/me'],
+    ['Settings', '#/settings'],
+  ];
+
+  function ensureChannels(){
+    const h = location.hash || '#/home';
+    if (!/^#\/($|home)/.test(h)) return;
+
+    const app = document.querySelector('#app') || document.body;
+
+    // Ensure home panel exists
+    let home = app.querySelector('.home-panel');
+    if (!home) {
+      home = document.createElement('div');
+      home.className = 'home-panel';
+      app.appendChild(home);
+    }
+
+    // Ensure channels grid exists
+    let grid = home.querySelector('.channels-grid');
+    if (!grid) {
+      grid = document.createElement('nav');
+      grid.className = 'channels-grid';
+      home.appendChild(grid);
+    }
+
+    // Ensure required anchors exist (deduped by href)
+    routes.forEach(([label, href]) => {
+      if (!grid.querySelector(`.channel-btn[href="${href}"]`)) {
+        const a = document.createElement('a');
+        a.className = 'channel-btn';
+        a.href = href;
+        a.textContent = label;
+        grid.appendChild(a);
+      }
+    });
+  }
+
+  window.addEventListener('hashchange', ensureChannels);
+  document.addEventListener('DOMContentLoaded', ensureChannels);
+  ensureChannels();
+})();

--- a/frontend/src/assets/js/home-map-pills.js
+++ b/frontend/src/assets/js/home-map-pills.js
@@ -1,0 +1,93 @@
+// home-map-pills.js — render Mon→Sat buttons under "Map" on #/home
+const CONFERENCE="gamescom2025";
+const PARTIES_URL=`/api/parties?conference=${encodeURIComponent(CONFERENCE)}`;
+
+const fmt = d => d.toISOString().slice(0,10);
+const parseDate = v => {
+  if (!v) return null;
+  const m = String(v).match(/\d{4}-\d{2}-\d{2}/);
+  return m ? new Date(m[0]+'T00:00:00Z') : null;
+};
+const weekMonToSat = (anchor) => {
+  const d = new Date(anchor);
+  const day = d.getUTCDay() || 7; // Sun=0 → 7
+  const monday = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() - (day-1)));
+  return Array.from({length:6},(_,i)=>new Date(Date.UTC(monday.getUTCFullYear(), monday.getUTCMonth(), monday.getUTCDate()+i)));
+};
+const label = d => {
+  const wd = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'][d.getUTCDay()];
+  const dd = String(d.getUTCDate()).padStart(2,'0');
+  return `${wd} ${dd}`;
+};
+
+async function getParties(){
+  try {
+    const r = await fetch(PARTIES_URL, { headers:{accept:'application/json'} });
+    const j = await r.json();
+    const list = Array.isArray(j?.data) ? j.data
+              : Array.isArray(j?.parties) ? j.parties
+              : Array.isArray(j) ? j : [];
+    return list;
+  } catch { return []; }
+}
+function pickAnchorDate(list){
+  const ds = list.map(p => parseDate(p.date || p.start || p.startsAt)).filter(Boolean).sort((a,b)=>a-b);
+  return ds[0] || new Date();
+}
+
+function mountMapPillsRow(){
+  const home = document.querySelector('.home-panel');
+  if (!home) return null;
+
+  // Find/create the "Map" section on Home
+  let mapSection = [...home.querySelectorAll('.home-section')].find(sec => {
+    const h = sec.querySelector('h2,h3,[role=heading]');
+    return h && /^map$/i.test(h.textContent.trim());
+  });
+  if (!mapSection) {
+    mapSection = document.createElement('section');
+    mapSection.className = 'home-section';
+    const h = document.createElement('h2');
+    h.textContent = 'Map';
+    mapSection.appendChild(h);
+    home.appendChild(mapSection);
+  }
+
+  let row = mapSection.querySelector('.day-pills');
+  if (!row) {
+    row = document.createElement('div');
+    row.className = 'day-pills';
+    mapSection.appendChild(row);
+  }
+  row.innerHTML = '';
+  return row;
+}
+
+function renderButtons(row, days){
+  const todayISO = new Date().toISOString().slice(0,10);
+  days.forEach(d => {
+    const iso = fmt(d);
+    const btn = document.createElement('button');
+    btn.className = 'day-pill';
+    btn.type = 'button';
+    btn.setAttribute('aria-pressed', String(iso===todayISO));
+    btn.dataset.href = `#/map/${iso}`;
+    btn.textContent = label(d);
+    btn.addEventListener('click', () => { location.hash = btn.dataset.href; });
+    row.appendChild(btn);
+  });
+}
+
+async function init(){
+  if ((location.hash || '#/home').split('#')[1] !== '/home') return;
+  const row = mountMapPillsRow();
+  if (!row) return;
+
+  const parties = await getParties();
+  const anchor = pickAnchorDate(parties);
+  const days = weekMonToSat(anchor);
+  renderButtons(row, days);
+}
+
+window.addEventListener('hashchange', init, { passive:true });
+document.addEventListener('DOMContentLoaded', init, { passive:true });

--- a/frontend/src/assets/js/home-mon-sat.js
+++ b/frontend/src/assets/js/home-mon-sat.js
@@ -1,0 +1,95 @@
+// home-mon-sat.js — render Mon→Sat day pills on Home from live data
+const CONFERENCE="gamescom2025";
+const PARTIES_URL=`/api/parties?conference=${encodeURIComponent(CONFERENCE)}`;
+
+const fmt = d => d.toISOString().slice(0,10);
+const parseDate = v => {
+  if (!v) return null;
+  const t = typeof v === 'string' ? v : String(v);
+  const m = t.match(/\d{4}-\d{2}-\d{2}/);
+  return m ? new Date(m[0]+'T00:00:00Z') : null;
+};
+
+const weekMonToSat = (anchor) => {
+  const d = new Date(anchor);
+  const day = d.getUTCDay() || 7; // Sun=0 → 7
+  const monday = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() - (day-1)));
+  return Array.from({length:6},(_,i)=>new Date(Date.UTC(monday.getUTCFullYear(), monday.getUTCMonth(), monday.getUTCDate()+i)));
+};
+
+const label = d => {
+  const wd = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'][d.getUTCDay()];
+  const dd = String(d.getUTCDate()).padStart(2,'0');
+  return `${wd} ${dd}`;
+};
+
+async function getParties() {
+  try {
+    const res = await fetch(PARTIES_URL, { headers:{accept:'application/json'} });
+    const json = await res.json();
+    const list = Array.isArray(json?.data) ? json.data
+               : Array.isArray(json?.parties) ? json.parties
+               : Array.isArray(json) ? json : [];
+    return list;
+  } catch { return []; }
+}
+
+function pickAnchorDate(list){
+  const dates = list
+    .map(p => parseDate(p.date || p.start || p.startsAt))
+    .filter(Boolean)
+    .sort((a,b)=>a-b);
+  return dates[0] || new Date(); // fallback today
+}
+
+function mountHomePills(){
+  // Find the Parties section on Home
+  const home = document.querySelector('.home-panel');
+  if (!home) return false;
+  const partiesSection = [...home.querySelectorAll('.home-section')].find(sec => {
+    const h = sec.querySelector('h2,h3,[role=heading]');
+    return h && /parties/i.test(h.textContent || '');
+  });
+  if (!partiesSection) return false;
+
+  // container (create if missing)
+  let row = partiesSection.querySelector('.day-pills');
+  if (!row) {
+    row = document.createElement('div');
+    row.className = 'day-pills';
+    partiesSection.appendChild(row);
+  }
+  row.innerHTML = ''; // reset
+
+  return row;
+}
+
+function renderButtons(row, days){
+  const todayISO = new Date().toISOString().slice(0,10);
+  days.forEach(d => {
+    const iso = fmt(d);
+    const btn = document.createElement('button');
+    btn.className = 'day-pill';
+    btn.type = 'button';
+    btn.setAttribute('aria-pressed', String(iso===todayISO));
+    btn.dataset.href = `#/parties/${iso}`;
+    btn.textContent = label(d);
+    btn.addEventListener('click', () => { location.hash = btn.dataset.href; });
+    row.appendChild(btn);
+  });
+}
+
+async function init(){
+  if ((location.hash || '#/home').split('?')[0].split('#')[1] !== '/home') return;
+  const row = mountHomePills();
+  if (!row) return;
+
+  const parties = await getParties();
+  const anchor = pickAnchorDate(parties);
+  const days = weekMonToSat(anchor);
+  renderButtons(row, days);
+}
+
+// re-run on hash change (stay tiny)
+window.addEventListener('hashchange', init, { passive:true });
+document.addEventListener('DOMContentLoaded', init, { passive:true });

--- a/frontend/src/assets/js/home-panel.js
+++ b/frontend/src/assets/js/home-panel.js
@@ -1,0 +1,73 @@
+/**
+ * Home panel: two sections (Parties / Map), each with Mon–Sat pills.
+ * Routes: #/parties/YYYY-MM-DD and #/map/YYYY-MM-DD
+ */
+export async function getMonSatDates() {
+  let data = [];
+  try {
+    const r = await fetch('/api/parties?conference=gamescom2025', { headers: { accept: 'application/json' }});
+    const raw = await r.json();
+    const list = Array.isArray(raw?.data) ? raw.data
+               : Array.isArray(raw?.parties) ? raw.parties
+               : Array.isArray(raw) ? raw : [];
+    data = list;
+  } catch { /* fallback below */ }
+
+  const toISO = s => (s || '').slice(0,10);
+  const day = iso => new Date(iso + 'T00:00:00').getDay(); // 0..6
+  let uniq = Array.from(new Set(
+    data.map(p => toISO(p.start || p.startsAt || p.date || ''))
+  )).filter(Boolean).sort();
+
+  // Keep Mon..Sat; fallback to next Mon..Sat if empty
+  let monSat = uniq.filter(iso => (day(iso) >= 1 && day(iso) <= 6));
+  if (!monSat.length) {
+    const now = new Date();
+    const nextMon = new Date(now);
+    nextMon.setDate(now.getDate() + ((1 - now.getDay() + 7) % 7 || 7)); // next Monday
+    monSat = Array.from({length:6}, (_,i) => {
+      const d = new Date(nextMon); d.setDate(nextMon.getDate()+i);
+      return d.toISOString().slice(0,10);
+    });
+  }
+  return monSat.slice(0,6);
+}
+
+function pillLabel(iso) {
+  const d = new Date(iso + 'T00:00:00');
+  const w = d.toLocaleDateString(undefined, { weekday:'short' });
+  const dd = d.toLocaleDateString(undefined, { day:'2-digit' });
+  return `${w} ${dd}`;
+}
+
+export function renderHomePanel(root, dates) {
+  root.innerHTML = `
+    <section class="home-panel">
+      <div class="home-section">
+        <h2 class="home-h2">Parties</h2>
+        <div class="pill-row" data-kind="parties">
+          ${dates.map(iso => `
+            <button class="day-pill" data-route="#/parties/${iso}" aria-pressed="false">${pillLabel(iso)}</button>
+          `).join('')}
+        </div>
+      </div>
+      <div class="home-section">
+        <h2 class="home-h2">Map</h2>
+        <div class="pill-row" data-kind="map">
+          ${dates.map((iso,i) => `
+            <button class="day-pill" data-route="#/map/${iso}" aria-pressed="${i===0?'true':'false'}">${pillLabel(iso)}</button>
+          `).join('')}
+        </div>
+      </div>
+    </section>
+  `;
+}
+
+export function wireHomePanel(root) {
+  root.addEventListener('click', (e) => {
+    const btn = e.target.closest('.day-pill');
+    if (!btn) return;
+    const to = btn.dataset.route;
+    if (to) location.hash = to;
+  });
+}

--- a/frontend/src/assets/js/home-parties-pills.js
+++ b/frontend/src/assets/js/home-parties-pills.js
@@ -1,0 +1,94 @@
+// home-parties-pills.js — Home → Parties section: Mon–Sat buttons (NOT links)
+const CONFERENCE="gamescom2025";
+const PARTIES_URL=`/api/parties?conference=${encodeURIComponent(CONFERENCE)}`;
+
+const fmtISO = d => d.toISOString().slice(0,10);
+const pickDate = v => {
+  if (!v) return null;
+  const m = String(v).match(/\d{4}-\d{2}-\d{2}/);
+  return m ? new Date(m[0]+'T00:00:00Z') : null;
+};
+const mondayThroughSaturday = (anchor) => {
+  const d = new Date(anchor);
+  const day = d.getUTCDay() || 7; // Sun=0 → 7
+  const monday = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() - (day-1)));
+  return Array.from({length:6},(_,i)=>new Date(Date.UTC(monday.getUTCFullYear(), monday.getUTCMonth(), monday.getUTCDate()+i)));
+};
+const label = d => {
+  const wd = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'][d.getUTCDay()];
+  const dd = String(d.getUTCDate()).padStart(2,'0');
+  return `${wd} ${dd}`;
+};
+
+async function fetchParties(){
+  try {
+    const r = await fetch(PARTIES_URL, { headers:{accept:'application/json'} });
+    const j = await r.json();
+    return Array.isArray(j?.data) ? j.data
+         : Array.isArray(j?.parties) ? j.parties
+         : Array.isArray(j) ? j : [];
+  } catch { return []; }
+}
+function anchorFromParties(list){
+  const ds = list.map(p => pickDate(p.date || p.start || p.startsAt)).filter(Boolean).sort((a,b)=>a-b);
+  return ds[0] || new Date();
+}
+
+function ensurePartiesSection(){
+  const home = document.querySelector('.home-panel');
+  if (!home) return null;
+
+  // Find/create the "Parties" section container
+  let sec = [...home.querySelectorAll('.home-section')].find(s => {
+    const h = s.querySelector('h2,h3,[role=heading]');
+    return h && /^parties$/i.test(h.textContent.trim());
+  });
+  if (!sec) {
+    sec = document.createElement('section');
+    sec.className = 'home-section';
+    const h = document.createElement('h2');
+    h.textContent = 'Parties';
+    sec.appendChild(h);
+    // Insert Parties section before Map section if possible
+    const mapSection = [...home.querySelectorAll('.home-section')].find(s => {
+      const h = s.querySelector('h2,h3,[role=heading]'); return h && /^map$/i.test(h.textContent.trim());
+    });
+    home.insertBefore(sec, mapSection || home.firstChild);
+  }
+
+  let row = sec.querySelector('.day-pills');
+  if (!row) {
+    row = document.createElement('div');
+    row.className = 'day-pills';
+    sec.appendChild(row);
+  }
+  row.innerHTML = '';
+  return row;
+}
+
+function renderButtons(row, days){
+  const todayISO = new Date().toISOString().slice(0,10);
+  days.forEach(d => {
+    const iso = fmtISO(d);
+    const btn = document.createElement('button');
+    btn.className = 'day-pill';
+    btn.type = 'button';
+    btn.setAttribute('aria-pressed', String(iso===todayISO));
+    btn.dataset.href = `#/parties/${iso}`;
+    btn.textContent = label(d);
+    btn.addEventListener('click', () => { location.hash = btn.dataset.href; });
+    row.appendChild(btn);
+  });
+}
+
+async function init(){
+  if ((location.hash || '#/home').split('#')[1] !== '/home') return;
+  const row = ensurePartiesSection();
+  if (!row) return;
+  const parties = await fetchParties();
+  const anchor = anchorFromParties(parties);
+  renderButtons(row, mondayThroughSaturday(anchor));
+}
+
+window.addEventListener('hashchange', init, { passive:true });
+document.addEventListener('DOMContentLoaded', init, { passive:true });

--- a/frontend/src/assets/js/home-pills-fix.js
+++ b/frontend/src/assets/js/home-pills-fix.js
@@ -1,0 +1,167 @@
+/**
+ * home-pills-fix.js
+ * Ensures Home panel renders two sections:
+ *   Parties — Mon..Sat pills → #/parties/YYYY-MM-DD
+ *   Map     — Mon..Sat pills → #/map/YYYY-MM-DD
+ * Data source: /api/parties?conference=gamescom2025 (fallback = current week)
+ * No inline styles, uses existing .day-pill styles, idempotent.
+ */
+(function(){
+  const CONF = 'gamescom2025';
+
+  // --- utils
+  const qs  = (s, r=document) => r.querySelector(s);
+  const qsa = (s, r=document) => [...r.querySelectorAll(s)];
+  const todayISO = () => new Date().toISOString().slice(0,10);
+
+  const toISO = (d) => {
+    const pad = (n)=> String(n).padStart(2,'0');
+    return `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())}`;
+  };
+  const fromISO = (s) => {
+    const [y,m,d] = s.split('-').map(Number);
+    return new Date(y, m-1, d);
+  };
+  const startOfISOWeek = (date) => {
+    const d = new Date(date);
+    const day = (d.getDay() || 7); // Mon=1..Sun=7
+    if (day > 1) d.setDate(d.getDate() - (day - 1));
+    return d;
+  };
+  const addDays = (d, n) => {
+    const x = new Date(d);
+    x.setDate(x.getDate() + n);
+    return x;
+  };
+  const labelFor = (d) => {
+    return d.toLocaleDateString(undefined, { weekday:'short', day:'2-digit' })
+      .replace(',', ''); // e.g., "Mon 18"
+  };
+
+  // Pick Monday..Saturday for the "best" week in data (else current week)
+  function pickWeekDates(uniqueISO){
+    if (uniqueISO.size) {
+      const sorted = [...uniqueISO].sort();
+      const min = fromISO(sorted[0]);
+      const startMon = startOfISOWeek(min);
+      return Array.from({length:6}, (_,i)=> toISO(addDays(startMon,i))); // Mon..Sat
+    } else {
+      const startMon = startOfISOWeek(new Date());
+      return Array.from({length:6}, (_,i)=> toISO(addDays(startMon,i)));
+    }
+  }
+
+  async function fetchPartyDates(){
+    try {
+      const res = await fetch(`/api/parties?conference=${encodeURIComponent(CONF)}`, {
+        headers: { accept: 'application/json' },
+        credentials: 'include'
+      });
+      const ct = res.headers.get('content-type') || '';
+      if (!res.ok || !ct.includes('application/json')) return new Set();
+      const json = await res.json();
+      const arr = Array.isArray(json?.data) ? json.data :
+                  Array.isArray(json?.parties) ? json.parties :
+                  Array.isArray(json) ? json : [];
+      const dates = new Set();
+      for (const e of arr) {
+        const iso = String(e.date || e.start || e.startsAt || '').slice(0,10);
+        if (/^\d{4}-\d{2}-\d{2}$/.test(iso)) dates.add(iso);
+      }
+      return dates;
+    } catch {
+      return new Set();
+    }
+  }
+
+  function ensureHomeShell(){
+    const app = qs('#app') || document.body;
+    let home = qs('.home-panel', app);
+    if (!home) {
+      home = document.createElement('div');
+      home.className = 'home-panel';
+      app.appendChild(home);
+    }
+    // Section helper
+    const ensureSection = (kind, titleText) => {
+      let sec = qs(`.home-section[data-kind="${kind}"]`, home);
+      if (!sec) {
+        sec = document.createElement('section');
+        sec.className = 'home-section';
+        sec.dataset.kind = kind;
+        const h = document.createElement('h2');
+        h.className = 'section-title';
+        h.textContent = titleText;
+        const pills = document.createElement('div');
+        pills.className = 'day-pills';
+        sec.append(h, pills);
+        home.appendChild(sec);
+      }
+      return sec;
+    };
+    return { home, ensureSection };
+  }
+
+  function renderPills(pillsEl, baseRoute, isoList){
+    // Keep exactly Mon..Sat (6 buttons). Replace content idempotently.
+    const desired = isoList.slice(0,6);
+    const current = qsa('button.day-pill', pillsEl).map(b => b.dataset.iso);
+    const same = desired.length===current.length && desired.every((d,i)=>d===current[i]);
+    if (!same) {
+      pillsEl.textContent = '';
+      desired.forEach(iso => {
+        const b = document.createElement('button');
+        b.className = 'day-pill';
+        b.type = 'button';
+        b.dataset.iso = iso;
+        b.dataset.href = `${baseRoute}/${iso}`;
+        b.setAttribute('aria-pressed','false');
+        b.textContent = labelFor(fromISO(iso));
+        pillsEl.appendChild(b);
+      });
+    }
+    // pressed state from hash
+    const {hash} = location;
+    const m = hash.match(/^#\/(map|parties)\/(\d{4}-\d{2}-\d{2})$/);
+    const activeISO = m?.[2] || null;
+    qsa('button.day-pill', pillsEl).forEach(btn => {
+      const pressed = btn.dataset.iso === activeISO;
+      btn.setAttribute('aria-pressed', pressed ? 'true' : 'false');
+    });
+  }
+
+  function wireClicks(home){
+    // Delegated clicks for .day-pill
+    home.addEventListener('click', (e) => {
+      const btn = e.target.closest('button.day-pill');
+      if (!btn) return;
+      const href = btn.dataset.href;
+      if (href) location.hash = href;
+    });
+  }
+
+  async function ensurePills(){
+    // Only act on #/home
+    if (!/^#\/($|home)/.test(location.hash || '#/home')) return;
+
+    const { ensureSection, home } = ensureHomeShell();
+    wireClicks(home);
+
+    const dataDates = await fetchPartyDates();
+    const week = pickWeekDates(dataDates);
+
+    const partiesSec = ensureSection('parties', 'Parties');
+    const mapSec     = ensureSection('map',     'Map');
+
+    const partiesPills = qs('.day-pills', partiesSec);
+    const mapPills     = qs('.day-pills', mapSec);
+
+    renderPills(partiesPills, '#/parties', week);
+    renderPills(mapPills,     '#/map',     week);
+  }
+
+  // keep pills in sync with route
+  window.addEventListener('hashchange', ensurePills);
+  document.addEventListener('DOMContentLoaded', ensurePills);
+  ensurePills();
+})();

--- a/frontend/src/assets/js/home-router-hotfix.js
+++ b/frontend/src/assets/js/home-router-hotfix.js
@@ -1,0 +1,59 @@
+import { getMonSatDates, renderHomePanel, wireHomePanel } from './home-panel.js';
+
+function byId(id){ return document.getElementById(id) || document.querySelector('#app') || document.body; }
+async function mountHome() {
+  const mount = byId('app');
+  const dates = await getMonSatDates();
+  renderHomePanel(mount, dates);
+  wireHomePanel(mount);
+}
+
+async function onRoute() {
+  const h = location.hash || '';
+  if (!h || h === '#/' || h === '#/home') {
+    await mountHome();
+    return;
+  }
+  // For parties/map, keep your existing panels.
+  // If none exists, provide minimal fallback for parties.
+  const mParties = /^#\/parties\/(\d{4}-\d{2}-\d{2})$/.exec(h);
+  if (mParties) {
+    const date = mParties[1];
+    const root = byId('app');
+    try {
+      const r = await fetch('/api/parties?conference=gamescom2025', { headers:{accept:'application/json'} });
+      const raw = await r.json();
+      const list = Array.isArray(raw?.data) ? raw.data
+                 : Array.isArray(raw?.parties) ? raw.parties
+                 : Array.isArray(raw) ? raw : [];
+      const items = list.filter(e => (e.start || e.startsAt || e.date || '').slice(0,10) === date);
+      root.innerHTML = `
+        <section class="parties-panel">
+          <h2 class="home-h2">Parties • ${date}</h2>
+          <div class="card-grid">
+            ${items.map(e => `
+              <article class="vcard">
+                <header class="vcard__head"><h3>${(e.title||e.name||'Party')}</h3></header>
+                <div class="vcard__body">
+                  <p>${(e.venue||e.location?.name||'')}</p>
+                  <p>${(e.start||e.startsAt||'').replace('T',' ')}</p>
+                </div>
+              </article>
+            `).join('')}
+          </div>
+        </section>
+      `;
+    } catch {
+      await mountHome();
+    }
+    return;
+  }
+  // If your existing router mounts the Map panel, let it handle #/map/DATE.
+  // Otherwise do nothing here (avoids conflicts). You already fixed the Maps loader.
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  if (!location.hash) location.hash = '#/home';
+  onRoute();
+});
+window.addEventListener('hashchange', onRoute);

--- a/frontend/src/assets/js/home-router-hotfix.js
+++ b/frontend/src/assets/js/home-router-hotfix.js
@@ -1,4 +1,5 @@
 import { getMonSatDates, renderHomePanel, wireHomePanel } from './home-panel.js';
+import { mountPartiesPanel } from './panels/parties-panel-lite.js';
 
 function byId(id){ return document.getElementById(id) || document.querySelector('#app') || document.body; }
 async function mountHome() {
@@ -19,33 +20,7 @@ async function onRoute() {
   const mParties = /^#\/parties\/(\d{4}-\d{2}-\d{2})$/.exec(h);
   if (mParties) {
     const date = mParties[1];
-    const root = byId('app');
-    try {
-      const r = await fetch('/api/parties?conference=gamescom2025', { headers:{accept:'application/json'} });
-      const raw = await r.json();
-      const list = Array.isArray(raw?.data) ? raw.data
-                 : Array.isArray(raw?.parties) ? raw.parties
-                 : Array.isArray(raw) ? raw : [];
-      const items = list.filter(e => (e.start || e.startsAt || e.date || '').slice(0,10) === date);
-      root.innerHTML = `
-        <section class="parties-panel">
-          <h2 class="home-h2">Parties • ${date}</h2>
-          <div class="card-grid">
-            ${items.map(e => `
-              <article class="vcard">
-                <header class="vcard__head"><h3>${(e.title||e.name||'Party')}</h3></header>
-                <div class="vcard__body">
-                  <p>${(e.venue||e.location?.name||'')}</p>
-                  <p>${(e.start||e.startsAt||'').replace('T',' ')}</p>
-                </div>
-              </article>
-            `).join('')}
-          </div>
-        </section>
-      `;
-    } catch {
-      await mountHome();
-    }
+    await mountPartiesPanel(date);
     return;
   }
   // If your existing router mounts the Map panel, let it handle #/map/DATE.

--- a/frontend/src/assets/js/map-subnav-lite.js
+++ b/frontend/src/assets/js/map-subnav-lite.js
@@ -1,0 +1,54 @@
+(function(){
+  const qs = s => document.querySelector(s);
+  const qsa = s => [...document.querySelectorAll(s)];
+
+  function ensureSubnav(dates){
+    let sub = qs('.v-day-subnav');
+    if (!sub){
+      sub = document.createElement('nav');
+      sub.className = 'v-day-subnav';
+      const host = qs('#app') || document.body;
+      host.prepend(sub);
+    }
+    sub.innerHTML = '';
+    dates.forEach(d => {
+      const b = document.createElement('button');
+      b.className = 'day-pill';
+      b.textContent = (new Date(d)).toLocaleDateString(undefined, { weekday:'short', day:'2-digit' }).replace(/\s?\,?\s?/g,' ');
+      b.dataset.route = `#/map/${d}`;
+      b.setAttribute('aria-pressed', 'false');
+      b.addEventListener('click', () => location.hash = b.dataset.route);
+      sub.appendChild(b);
+    });
+    return sub;
+  }
+
+  async function dedupeDates(){
+    try {
+      const r = await fetch('/api/parties?conference=gamescom2025', { headers:{accept:'application/json'} });
+      const j = await r.json().catch(()=> ({}));
+      const list = Array.isArray(j?.data) ? j.data : Array.isArray(j?.parties) ? j.parties : Array.isArray(j) ? j : [];
+      return [...new Set(list.map(e => (e.date||e.start||'').slice(0,10)).filter(Boolean))].sort().slice(0,6);
+    } catch { return []; }
+  }
+
+  async function onRoute(){
+    const h = location.hash || '#/home';
+    const onMap = /^#\/map(\/|$)/.test(h);
+    const sub = qs('.v-day-subnav');
+
+    if (!onMap){ sub?.remove(); return; }
+
+    const dates = (await dedupeDates());
+    const nav = ensureSubnav(dates.length ? dates : [new Date().toISOString().slice(0,10)]);
+    // pressed state
+    const m = /^#\/map\/(\d{4}-\d{2}-\d{2})/.exec(h);
+    const target = m ? m[1] : null;
+    qsa('.v-day-subnav .day-pill').forEach(b => {
+      b.setAttribute('aria-pressed', String(!!(target && b.dataset.route.endsWith(target))));
+    });
+  }
+
+  window.addEventListener('hashchange', onRoute);
+  document.addEventListener('DOMContentLoaded', onRoute);
+})();

--- a/frontend/src/assets/js/panels/parties-panel-lite.js
+++ b/frontend/src/assets/js/panels/parties-panel-lite.js
@@ -1,0 +1,97 @@
+/**
+ * Parties panel (lite): renders parties for a YYYY-MM-DD date.
+ * Fallback ICS add-to-calendar (client-side) to ensure UX works without backend.
+ */
+function escape(s=''){ return String(s).replace(/[&<>"]/g, m=>({ '&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;' }[m])); }
+function isoDate(s){ return (s||'').slice(0,10); }
+function toICSDate(s){
+  // accepts ISO like 2025-08-21T19:00:00Z or 2025-08-21
+  const d = s && s.length>10 ? new Date(s) : new Date(s+'T00:00:00');
+  const pad = n => String(n).padStart(2,'0');
+  const y=d.getUTCFullYear(), m=pad(d.getUTCMonth()+1), day=pad(d.getUTCDate());
+  const hh=pad(d.getUTCHours()), mm=pad(d.getUTCMinutes()), ss=pad(d.getUTCSeconds());
+  return `${y}${m}${day}T${hh}${mm}${ss}Z`;
+}
+function buildICS(evt){
+  const uid = `party-${(evt.id||evt.title||evt.name||'x').replace(/\W+/g,'-')}@conference-party-app`;
+  const dtStart = toICSDate(evt.start || evt.startsAt || evt.date);
+  const dtEnd   = toICSDate(evt.end   || evt.endsAt   || evt.start || evt.date);
+  const title   = escape(evt.title || evt.name || 'Party');
+  const loc     = escape(evt.venue || evt.location?.name || '');
+  const desc    = escape((evt.description || '').slice(0,1000));
+  return [
+    'BEGIN:VCALENDAR','VERSION:2.0','PRODID:-//Conference Party App//EN','CALSCALE:GREGORIAN',
+    'BEGIN:VEVENT',
+    `UID:${uid}`,
+    `DTSTAMP:${toICSDate(new Date().toISOString())}`,
+    `DTSTART:${dtStart}`,
+    `DTEND:${dtEnd}`,
+    `SUMMARY:${title}`,
+    loc && `LOCATION:${loc}`,
+    desc && `DESCRIPTION:${desc}`,
+    'END:VEVENT','END:VCALENDAR',''
+  ].filter(Boolean).join('\r\n');
+}
+function downloadICS(evt){
+  const ics = buildICS(evt);
+  const blob = new Blob([ics], { type:'text/calendar;charset=utf-8' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  const date = isoDate(evt.start||evt.startsAt||evt.date)||'date';
+  a.href = url; a.download = `party-${date}.ics`;
+  document.body.appendChild(a); a.click(); a.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+export async function mountPartiesPanel(dateISO){
+  const mount = document.getElementById('app') || document.body;
+  mount.innerHTML = `
+    <section class="parties-panel">
+      <h2 class="home-h2">Parties • ${dateISO}</h2>
+      <div class="card-grid" id="parties-list" aria-live="polite"></div>
+    </section>
+  `;
+  const listEl = mount.querySelector('#parties-list');
+
+  let raw;
+  try {
+    const r = await fetch('/api/parties?conference=gamescom2025', { headers:{accept:'application/json'} });
+    raw = await r.json();
+  } catch (e) {
+    listEl.innerHTML = `<p class="empty-state">Could not load parties.</p>`;
+    return;
+  }
+  const all = Array.isArray(raw?.data) ? raw.data
+           : Array.isArray(raw?.parties) ? raw.parties
+           : Array.isArray(raw) ? raw : [];
+  const items = all.filter(e => isoDate(e.start||e.startsAt||e.date) === dateISO);
+
+  if (!items.length){
+    listEl.innerHTML = `<p class="empty-state">No parties for ${dateISO}.</p>`;
+    return;
+  }
+
+  listEl.innerHTML = items.map(evt => {
+    const title = escape(evt.title||evt.name||'Party');
+    const when  = escape((evt.start||evt.startsAt||'').replace('T',' ').slice(0,16));
+    const where = escape(evt.venue || evt.location?.name || '');
+    return `
+      <article class="vcard">
+        <header class="vcard__head"><h3>${title}</h3></header>
+        <div class="vcard__body">
+          ${where ? `<p>${where}</p>`:''}
+          ${when  ? `<p>${when}</p>`:''}
+        </div>
+        <footer class="vcard__foot">
+          <button class="btn-add-to-calendar" data-evt='${encodeURIComponent(JSON.stringify(evt))}'>Add to Calendar</button>
+        </footer>
+      </article>`;
+  }).join('');
+
+  listEl.addEventListener('click', (e)=>{
+    const btn = e.target.closest('.btn-add-to-calendar');
+    if(!btn) return;
+    const evt = JSON.parse(decodeURIComponent(btn.dataset.evt||'%7B%7D'));
+    downloadICS(evt);
+  });
+}

--- a/frontend/src/assets/js/parties-lite.js
+++ b/frontend/src/assets/js/parties-lite.js
@@ -1,0 +1,52 @@
+(function(){
+  const CONF = 'gamescom2025';
+  const qs = s => document.querySelector(s);
+
+  function card(evt){
+    const d = document.createElement('article');
+    d.className = 'vcard';
+    d.innerHTML = `
+      <header class="vcard-h">
+        <h3 class="title">${(evt.title||evt.name||'Party')}</h3>
+        <div class="meta">${(evt.venue||'')}</div>
+      </header>
+      <div class="vcard-b">
+        <div class="time">${(evt.start||evt.date||'').toString().slice(0,16)}</div>
+      </div>
+    `;
+    return d;
+  }
+
+  function wrap(){ const w=document.createElement('div'); w.className='parties-panel'; return w; }
+
+  async function render(dateIso){
+    const root = qs('#app') || document.body;
+    qs('.parties-panel')?.remove();
+    const panel = wrap();
+    root.appendChild(panel);
+
+    let list=[];
+    try {
+      const r = await fetch(`/api/parties?conference=${CONF}`, { headers:{accept:'application/json'} });
+      const j = await r.json().catch(()=> ({}));
+      const all = Array.isArray(j?.data) ? j.data : Array.isArray(j?.parties) ? j.parties : Array.isArray(j) ? j : [];
+      list = all.filter(e => (e.date||e.start||'').slice(0,10) === dateIso);
+    } catch {}
+
+    if (!list.length){
+      panel.innerHTML = `<div class="empty-state">No parties for ${dateIso}</div>`;
+      return;
+    }
+    const grid = document.createElement('section');
+    grid.className = 'card-grid';
+    list.forEach(e => grid.appendChild(card(e)));
+    panel.appendChild(grid);
+  }
+
+  function onRoute(){
+    const m = /#\/parties\/(\d{4}-\d{2}-\d{2})/.exec(location.hash||'');
+    if (m) render(m[1]); else qs('.parties-panel')?.remove();
+  }
+  window.addEventListener('hashchange', onRoute);
+  document.addEventListener('DOMContentLoaded', onRoute);
+})();

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -42,5 +42,6 @@
   <script defer src="/assets/js/home-channels-fix.js"></script>
   <script defer src="/assets/js/home-pills-fix.js"></script>
   <script type="module" src="/assets/js/home-mon-sat.js" defer></script>
+  <script type="module" src="/assets/js/home-map-pills.js" defer></script>
 </body>
 </html>

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -40,5 +40,6 @@
   <script defer src="/assets/js/parties-lite.js"></script>
   <script defer src="/assets/js/map-subnav-lite.js"></script>
   <script defer src="/assets/js/home-channels-fix.js"></script>
+  <script defer src="/assets/js/home-pills-fix.js"></script>
 </body>
 </html>

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -36,5 +36,8 @@
   <script defer src="/js/boot/map-boot.js"></script>
   <script type="module" src="/assets/js/home-panel.js" defer></script>
   <script type="module" src="/assets/js/home-router-hotfix.js" defer></script>
+  <script defer src="/assets/js/home-bootstrap.js"></script>
+  <script defer src="/assets/js/parties-lite.js"></script>
+  <script defer src="/assets/js/map-subnav-lite.js"></script>
 </body>
 </html>

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -34,5 +34,7 @@
   <script type="module" src="/dist/js/stack.js"></script>
   <script type="module" src="/dist/js/router-stack.js"></script>
   <script defer src="/js/boot/map-boot.js"></script>
+  <script type="module" src="/assets/js/home-panel.js" defer></script>
+  <script type="module" src="/assets/js/home-router-hotfix.js" defer></script>
 </body>
 </html>

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -41,5 +41,6 @@
   <script defer src="/assets/js/map-subnav-lite.js"></script>
   <script defer src="/assets/js/home-channels-fix.js"></script>
   <script defer src="/assets/js/home-pills-fix.js"></script>
+  <script type="module" src="/assets/js/home-mon-sat.js" defer></script>
 </body>
 </html>

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -39,5 +39,6 @@
   <script defer src="/assets/js/home-bootstrap.js"></script>
   <script defer src="/assets/js/parties-lite.js"></script>
   <script defer src="/assets/js/map-subnav-lite.js"></script>
+  <script defer src="/assets/js/home-channels-fix.js"></script>
 </body>
 </html>

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -43,5 +43,6 @@
   <script defer src="/assets/js/home-pills-fix.js"></script>
   <script type="module" src="/assets/js/home-mon-sat.js" defer></script>
   <script type="module" src="/assets/js/home-map-pills.js" defer></script>
+  <script type="module" src="/assets/js/home-parties-pills.js" defer></script>
 </body>
 </html>

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -18,8 +18,8 @@
   <link rel="stylesheet" href="/assets/css/components.css">
   <link rel="stylesheet" href="/assets/css/calendar-buttons.css">
   <!-- Home panel styles must load before cards-final to allow cascade -->
-  <link rel="stylesheet" href="/assets/css/home.css?v=b033">
-  <link rel="stylesheet" href="/assets/css/cards-final.css?v=b033">
+  <link rel="stylesheet" href="/assets/css/home.css?v=1755355966">
+  <link rel="stylesheet" href="/assets/css/cards-final.css?v=1755355966">
 </head>
 <body>
   <div id="app">

--- a/frontend/src/js/init-app.js
+++ b/frontend/src/js/init-app.js
@@ -1,6 +1,12 @@
 // init-app.js - Initialize the app with wired home panel
 import { renderHome } from './panels/home-wired.js';
 import { wireGlobalButtons } from './wire-buttons.js';
+import { renderHomeSections } from './panels/home-sections.js';
+
+export async function bootHome() {
+  const host = document.getElementById('app') || document.body;
+  await renderHomeSections(host);
+}
 
 // Wire buttons once on DOM ready
 document.addEventListener('DOMContentLoaded', () => wireGlobalButtons(document));

--- a/frontend/src/js/panels/home-sections.js
+++ b/frontend/src/js/panels/home-sections.js
@@ -1,0 +1,50 @@
+import { navigateTo } from '../router-stack.js';
+
+// Derive Mon→Sat from API, else fallback to Gamescom week
+async function getWeekDays() {
+  try {
+    const res = await fetch('/api/parties?conference=gamescom2025', { headers: {accept:'application/json'}});
+    const raw = await res.json().catch(()=>null) || {};
+    const arr = Array.isArray(raw?.data) ? raw.data
+              : Array.isArray(raw?.parties) ? raw.parties
+              : Array.isArray(raw) ? raw : [];
+    const dates = [...new Set(arr
+      .map(e => (e.date || e.start || e.startsAt || '').slice(0,10))
+      .filter(Boolean))].sort();
+    // Prefer exactly 6 unique days if available
+    if (dates.length >= 6) return dates.slice(0,6);
+  } catch {}
+  // Fallback Mon→Sat (Gamescom week)
+  return ['2025-08-18','2025-08-19','2025-08-20','2025-08-21','2025-08-22','2025-08-23'];
+}
+
+function labelFor(iso) {
+  const dt = new Date(iso + 'T00:00:00');
+  const wd = dt.toLocaleDateString(undefined, { weekday:'short' }); // Mon
+  const dd = dt.toLocaleDateString(undefined, { day:'2-digit' });   // 18
+  return `${wd} ${dd}`;
+}
+
+export async function renderHomeSections(host) {
+  const days = await getWeekDays();
+  const $ = document.createElement('section');
+  $.className = 'home-panel';
+  $.innerHTML = `
+    <header class="home-head"><h1 class="home-title">Parties</h1></header>
+    <div class="home-days" role="group" aria-label="Parties by day">
+      ${days.map(d => `<button class="channel-btn" data-route="#/parties/${d}">${labelFor(d)}</button>`).join('')}
+    </div>
+
+    <header class="home-head"><h1 class="home-title">Map</h1></header>
+    <div class="home-days" role="group" aria-label="Map by day">
+      ${days.map(d => `<button class="channel-btn" data-route="#/map/${d}">${labelFor(d)}</button>`).join('')}
+    </div>
+  `;
+
+  host.replaceChildren($);
+  $.addEventListener('click', (e) => {
+    const btn = e.target.closest('.channel-btn');
+    if (!btn) return;
+    navigateTo(btn.dataset.route);
+  });
+}

--- a/frontend/src/js/panels/map-day.js
+++ b/frontend/src/js/panels/map-day.js
@@ -1,0 +1,79 @@
+// Panels: Map by Day (MonSat)
+// Route: #/map/YYYY-MM-DD
+
+function toISO(d){ return (d||'').slice(0,10); }
+function labelFor(iso){
+  const dt = new Date(iso + 'T00:00:00');
+  const wd = dt.toLocaleDateString(undefined, { weekday:'short' });
+  const dd = dt.toLocaleDateString(undefined, { day:'2-digit' });
+  return `${wd} ${dd}`;
+}
+
+async function fetchParties() {
+  const res = await fetch('/api/parties?conference=gamescom2025', {
+    headers: { 'accept':'application/json' },
+    credentials: 'same-origin'
+  });
+  let raw=null; try { raw = await res.json(); } catch {}
+  const arr = Array.isArray(raw?.data) ? raw.data
+           : Array.isArray(raw?.parties) ? raw.parties
+           : Array.isArray(raw) ? raw : [];
+  return arr;
+}
+
+function normalize(p){
+  const title = p.title || p.name || 'Party';
+  const start = p.start || p.startsAt || p.date || '';
+  const date  = toISO(start || p.date || '');
+  const lat   = Number(p.lat ?? p.latitude ?? p.location?.lat ?? p.coords?.lat);
+  const lng   = Number(p.lng ?? p.longitude ?? p.location?.lng ?? p.coords?.lng);
+  return { title, date, lat, lng };
+}
+
+export async function mountMapDay(iso) {
+  const host = document.getElementById('app') || document.body;
+  const wrap = document.createElement('section');
+  wrap.className = 'panel panel-map-day';
+  wrap.innerHTML = `
+    <header class="panel-head">
+      <button class="back-btn" aria-label="Back" data-route="#/home">ê</button>
+      <h2 class="panel-title">Map  ${labelFor(iso)}</h2>
+    </header>
+    <div id="map-container" style="height:calc(100vh - 56px);"></div>
+  `;
+  host.replaceChildren(wrap);
+
+  // guard: require Maps JS (single loader already on page)
+  if (!(window.google?.maps?.marker?.AdvancedMarkerElement)) {
+    console.warn('Google Maps not ready.');
+    return;
+  }
+
+  const center = { lat: 50.9375, lng: 6.9603 }; // Cologne
+  const map = new google.maps.Map(wrap.querySelector('#map-container'), {
+    center, zoom: 12, mapId: 'DEMO_MAP_ID'
+  });
+
+  const all = (await fetchParties()).map(normalize);
+  const list = all.filter(p => Number.isFinite(p.lat) && Number.isFinite(p.lng) && p.date === iso);
+
+  const bounds = new google.maps.LatLngBounds();
+  for (const it of list) {
+    const pin = document.createElement('div');
+    pin.textContent = 'œ';
+    pin.style.fontSize = '18px';
+    pin.style.lineHeight = '18px';
+    pin.style.filter = 'drop-shadow(0 2px 4px rgba(0,0,0,.45))';
+    pin.style.color = '#6b7bff';
+    new google.maps.marker.AdvancedMarkerElement({
+      map, position: { lat: it.lat, lng: it.lng }, content: pin, title: it.title
+    });
+    bounds.extend({ lat: it.lat, lng: it.lng });
+  }
+  if (list.length) map.fitBounds(bounds, 48);
+
+  wrap.addEventListener('click', (e) => {
+    const back = e.target.closest('.back-btn');
+    if (back) { e.preventDefault(); history.back(); return; }
+  });
+}

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "validate:tokens": "bash tools/validate-tokens.sh",
     "migrate:tokens": "bash tools/migrate-to-tokens.sh preview",
     "migrate:tokens:apply": "bash tools/migrate-to-tokens.sh apply",
-    "build:update": "node tools/update-build.js"
+    "build:update": "node tools/update-build.js",
+    "guard:day-pills": "tools/guards/guard-day-pills.sh"
   },
   "dependencies": {
     "firebase-admin": "^12.7.0",

--- a/public/js/cache-utils.js
+++ b/public/js/cache-utils.js
@@ -2,7 +2,7 @@
  * 🛠️ GAMESCOM 2025 - CACHE UTILITIES
  * 
  * Client-side cache management and offline capabilities
- * Generated: 2025-08-15T21:30:32.889Z
+ * Generated: 2025-08-16T14:18:03.720Z
  */
 
 class CacheUtils {

--- a/public/js/offline-search.js
+++ b/public/js/offline-search.js
@@ -2,7 +2,7 @@
  * 🔍 GAMESCOM 2025 - OFFLINE SEARCH
  * 
  * Complete offline search functionality using cached data
- * Generated: 2025-08-15T21:30:32.888Z
+ * Generated: 2025-08-16T14:18:03.719Z
  * Events: 58
  */
 

--- a/public/sw.js
+++ b/public/sw.js
@@ -2,7 +2,7 @@
  * 🚀 GAMESCOM 2025 PARTY DISCOVERY - SERVICE WORKER
  * 
  * Offline-first PWA functionality with intelligent caching
- * Generated: 2025-08-15T21:30:32.884Z
+ * Generated: 2025-08-16T14:18:03.715Z
  * Cache Version: 1.0.0
  */
 

--- a/tools/guards/guard-day-pills.sh
+++ b/tools/guards/guard-day-pills.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# Fail if any anchor uses the day-pill class anywhere in active source.
+PATTERN='<a[^>]*class=[^"]*\bday-pill\b'
+if grep -RIn --include="*.html" --include="*.js" --include="*.mjs" --include="*.ts" \
+  -E "$PATTERN" frontend/src 2>/dev/null; then
+  echo "❌ Found .day-pill on an <a>. Day pills must be <button> only."
+  exit 1
+fi
+echo "✅ No anchors with .day-pill found (buttons-only confirmed)."


### PR DESCRIPTION
Adds Home → Parties section with Mon–Sat buttons that route to #/parties/YYYY-MM-DD. CSP-safe (module+defer). Uses live /api/parties to anchor the week.